### PR TITLE
Otp jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -192,6 +192,10 @@
 	     <exclude name="lib/wx-*/**" />
 	     <exclude name="lib/hipe-*/**" />
 	     <exclude name="lib/jinterface-*/**" />
+	     <exclude name="lib/erl_interface-*/**" />
+	     <exclude name="lib/ic-*/java_src/**" />
+	     <exclude name="usr/include/**" />
+	     <exclude name="**/examples/**" />
 	  </jar>
 	</target>
 


### PR DESCRIPTION
I'm currently working on ewarp, a WAR packager for Erlang apps based on Erjang, so they can be run in any Servlet container, e.g. on Tomcat running in the cloud (Amazon Elastic Beanstalk, CloudFoundry, ...). It's in the very early stages, see https://github.com/jetztgradnet/ewarp for details.

In order to package both Erjang and a OTP runtime, Krestens recent support for embedding OTP into the Erjang jar is great. These two commits change the ant build.xml to exclude some more files and add another task to create a jar file, which contains only OTP, no Erjang.

I switched Ant target names, so "otpjar" is the jar with only OTP and "alljar" is a new target, which creates a jar containing both Erjang and OTP. I also changed the name of this jar file to contain both the Erjang version as well as the OTP version.
