### PR TITLE
Implement maps

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -85,6 +85,7 @@
 
   <target name="compile" depends="gen-interpreter,create-dirs">
     <echo message="Compiling src ===================" />
+  	<echo message="** expect 7 warnings about sun.misc.Signal ** " />
     <javac includeantruntime="false" debug="true" srcdir="src/main/java" destdir="target/classes" classpathref="erjang.classpath" deprecation="off" debuglevel="lines,vars,source" target="1.7" source="1.7" fork="true"/>
   </target>
 

--- a/src/main/java/erjang/EExternal.java
+++ b/src/main/java/erjang/EExternal.java
@@ -88,6 +88,9 @@ public class EExternal {
     /** The tag used for small atoms */
     public static final int smallAtomTag = 115;
 
+    /** The tag used for small atoms */
+    public static final int mapTag = 116;
+
     /** The tag used for old Funs */
     public static final int funTag = 117;
 

--- a/src/main/java/erjang/EInputStream.java
+++ b/src/main/java/erjang/EInputStream.java
@@ -875,6 +875,23 @@ public class EInputStream extends ByteArrayInputStream {
 		return arity;
 	}
 
+	  public int read_map_head() throws IOException {
+		  int arity = 0;
+		  final int tag = read1skip_version();
+		  
+		  // decode the map header and get arity
+		  switch (tag) {
+		  case EExternal.mapTag:
+			  	arity = read4BE();
+			  	break;
+		  
+		  default:
+			  throw new IOException("Not valid map tag: " + tag);
+		  }
+		  
+		  return arity;
+	  }
+	
 	/**
 	 * Read a tuple header from the stream.
 	 * 
@@ -1248,6 +1265,9 @@ public class EInputStream extends ByteArrayInputStream {
 			
 		case EExternal.externalFunTag:
 			return read_external_fun();
+
+		case EExternal.mapTag:
+			return EMap.read(this);
 
 		default:
 			throw new IOException("Unknown data type: " + tag + " at position " + getPos());

--- a/src/main/java/erjang/EMap.java
+++ b/src/main/java/erjang/EMap.java
@@ -229,6 +229,7 @@ public final class EMap extends EObject {
                 throw ERT.badarg(list);
             }
             res = res.assoc(t.elem1, t.elem2);
+            list = list.tail();
         }
         return new EMap(res);
     }

--- a/src/main/java/erjang/EMap.java
+++ b/src/main/java/erjang/EMap.java
@@ -1,0 +1,341 @@
+/**
+ * This file is part of Erjang - A JVM-based Erlang VM
+ *
+ * Copyright (c) 2015 by Trifork
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+
+package erjang;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import com.trifork.clj_ds.IMapEntry;
+import com.trifork.clj_ds.IPersistentMap;
+import com.trifork.clj_ds.ISeq;
+import com.trifork.clj_ds.PersistentHashMap;
+import com.trifork.clj_ds.PersistentTreeMap;
+
+import erjang.m.ets.EMatchContext;
+import erjang.m.ets.EPattern;
+import erjang.m.ets.ETermPattern;
+
+public final class EMap extends EObject {
+
+    public static final EMap EMPTY = new EMap();
+	private final IPersistentMap<EObject,EObject> _map;
+
+	
+	public EMap() {
+        _map = new PersistentTreeMap<EObject, EObject>(null, EObject.ERLANG_ORDERING);
+    }
+
+    public EMap(IPersistentMap<EObject,EObject> it) {
+        _map = it;
+    }
+
+    public EMap testMap() {
+        return this;
+    }
+    
+	int cmp_order() { return CMP_ORDER_MAP; }
+	
+	@Override
+	public EAtom is_map() {
+		return ERT.TRUE;
+	}
+
+	@Override
+	int compare_same(EObject rhs) {
+		EMap other = rhs.testMap();
+		if (other == null) throw ERT.badarg(this, rhs);
+		
+		int mysize    = _map.count();
+		int othersize = other._map.count();
+		
+		// compare sizes
+		if (mysize < othersize) return -1;
+		if (othersize > mysize) return 1;
+		
+		// then compare the keys
+		ISeq<IMapEntry<EObject, EObject>> seq1 = _map.seq();
+		ISeq<IMapEntry<EObject, EObject>> seq2 = other._map.seq();
+				
+		while (seq1 != null)
+        {
+        	IMapEntry<EObject, EObject> ent1 = seq1.first();
+        	IMapEntry<EObject, EObject> ent2 = seq2.first();
+
+        	int keycompare = ent1.getKey().erlangCompareTo( ent2.getKey() );
+        	if (keycompare != 0) return keycompare;
+        	
+        	seq1 = seq1.next();
+        	seq2 = seq2.next();
+        }
+
+		// finally, all keys must be the same so we compare the values
+		seq1 = _map.seq();
+		seq2 = other._map.seq();
+				
+		while (seq1 != null)
+        {
+        	IMapEntry<EObject, EObject> ent1 = seq1.first();
+        	IMapEntry<EObject, EObject> ent2 = seq2.first();
+
+        	int keycompare = ent1.getValue().erlangCompareTo( ent2.getValue() );
+        	if (keycompare != 0) return keycompare;
+        	
+        	seq1 = seq1.next();
+        	seq2 = seq2.next();
+        }
+
+		return 0;
+	}
+
+	/**
+	 * @return true if this term matches the given matcher
+	 */
+	public boolean match(ETermPattern matcher, EMatchContext r) {
+		return matcher.match(this, r);
+	}
+
+	/**
+	 * @param out
+	 * @return
+	 */
+	public ETermPattern compileMatch(Set<Integer> out) {
+		return EPattern.compilePattern(this, out);
+	}
+	
+	@Override
+	public Type emit_const(MethodVisitor mv) {
+
+//		System.out.println("EMIT" +this);
+		
+		Type type = Type.getType(this.getClass());
+
+		mv.visitFieldInsn(Opcodes.GETSTATIC, type.getInternalName(), "EMPTY", "Lerjang/EMap;");
+
+        for(ISeq<IMapEntry<EObject, EObject>> iit = _map.seq();
+        		iit != null;
+        		iit = iit.next())
+        {
+        	IMapEntry<EObject, EObject> ent = iit.first();
+
+//        	System.out.println("CONST #{ "+ ent.getKey() + " => " + ent.getValue() + "}");
+        	
+        	ent.getKey().emit_const(mv);
+        	ent.getValue().emit_const(mv);
+        	mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, type.getInternalName(), "put", "(Lerjang/EObject;Lerjang/EObject;)Lerjang/EMap;");
+        }
+
+		return type;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder("#{");
+		boolean first = true;
+        for(ISeq<IMapEntry<EObject, EObject>> iit = _map.seq();
+        		iit != null;
+        		iit = iit.next())
+        {
+			if (!first)
+				sb.append(',');
+			else
+				first = false;
+
+        	IMapEntry<EObject, EObject> ent = iit.first();
+        	sb.append( ent.getKey() ).append("=>").append(ent.getValue());
+        }
+		sb.append("}");
+		return sb.toString();
+	}
+
+
+
+    public int hashCode() {
+        return to_list().hashCode();
+    }
+
+    public EObject get(EObject key) {
+        EObject v = _map.valAt(key, null);
+        if (v == null) {
+            throw ERT.badkey(key);
+        }
+        return v;
+    }
+
+    public EObject get(EObject key, EObject defaultValue) {
+        return _map.valAt(key, defaultValue);
+    }
+
+    public EObject find(EObject key) {
+        EObject v = _map.valAt(key, null);
+        if (v == null) {
+            return ERT.am_error;
+        }
+        return new ETuple2(ERT.am_ok, v);
+    }
+
+    public EMap put(EObject key, EObject value) {
+    	
+		EMap res = new EMap( _map.assoc(key, value) );
+		
+//    	System.out.println( String.valueOf(this) + ".put("+key+","+ value+ ") => "+res);
+
+		return res;
+	}
+
+    public EMap update(EObject key, EObject value) {
+    	if (!_map.containsKey(key)) throw ERT.badkey(key);
+    	return put(key, value);
+    }
+    
+    public EMap remove(EObject key) {
+    	if (_map.containsKey(key)) {
+			try {
+				return new EMap( _map.without(key) );
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+    	} else {
+    		return this;
+    	}
+	}
+    
+    
+    public static EMap from_list(ESeq list) {
+        IPersistentMap<EObject,EObject> res = PersistentHashMap.EMPTY;
+        while (!list.isNil()) {
+            ETuple2 t = ETuple2.cast(list.head());
+            if (t == null) {
+                throw ERT.badarg(list);
+            }
+            res = res.assoc(t.elem1, t.elem2);
+        }
+        return new EMap(res);
+    }
+    
+    // used by codegen
+    public boolean has_key(EObject key) {
+    	
+    	boolean res = _map.containsKey(key);
+    	
+//    	System.out.println( String.valueOf(this) + ".has_key("+key+") => "+res);
+//    	
+//    	if (res == false) {
+//    		(new Throwable()).printStackTrace();
+//    	}
+    	
+    	return res;
+    }
+    
+    public EAtom is_key(EObject key) {
+    	return ERT.box( _map.containsKey(key) );
+    }
+    
+    public ESeq to_list() {
+        ESeq it = ERT.NIL;
+        for(ISeq<IMapEntry<EObject, EObject>> iit = _map.seq();
+        		iit != null;
+        		iit = iit.next())
+        {
+        	IMapEntry<EObject, EObject> ent = iit.first();
+        	it = it.cons( new ETuple2( ent.getKey(), ent.getValue()  ));
+        }
+        return it;
+    }
+
+    public ESeq keys() {
+        ESeq it = ERT.NIL;
+        for(ISeq<IMapEntry<EObject, EObject>> iit = _map.seq();
+        		iit != null;
+        		iit = iit.next())
+        {
+        	IMapEntry<EObject, EObject> ent = iit.first();
+        	it = it.cons( ent.getKey() );
+        }
+        return it;
+    }
+    
+    public ESeq values() {
+        ESeq it = ERT.NIL;
+        for(ISeq<IMapEntry<EObject, EObject>> iit = _map.seq();
+        		iit != null;
+        		iit = iit.next())
+        {
+        	IMapEntry<EObject, EObject> ent = iit.first();
+        	it = it.cons( ent.getValue() );
+        }
+        return it;
+    }
+    
+    public EMap merge(EMap other)
+    {
+    	IPersistentMap<EObject, EObject> res = _map;
+        for(ISeq<IMapEntry<EObject, EObject>> iit = other._map.seq();
+        		iit != null;
+        		iit = iit.next())
+        {
+        	IMapEntry<EObject, EObject> ent = iit.first();
+        	res = res.assoc(ent.getKey(), ent.getValue());
+        }
+        return new EMap(res);
+    }
+
+	public boolean containsKey(EObject key) {
+		return _map.containsKey(key);
+	}
+
+	public int map_size() {
+		return _map.count();
+	}
+
+	public EMap put_map_assoc(EObject prefetched2, EObject prefetched3) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	public EMap put_map_exact(EObject prefetched2, EObject prefetched3) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	public static EMap read(EInputStream buf) throws IOException {
+		final int arity = buf.read_map_head();
+
+		if (arity > 0) {
+		    IPersistentMap<EObject,EObject> _m = EMPTY._map;
+
+		    for (int i = 0; i < arity; i++) {
+		    	EObject key = buf.read_any();
+		    	EObject value = buf.read_any();
+		    	_m = _m.assoc(key, value);
+		    }
+		    
+//		    System.out.println("DID READ "+(new EMap(_m)));
+		    
+		    return new EMap(_m);
+		} else {
+			return EMPTY;
+		}
+	}
+    
+}

--- a/src/main/java/erjang/EMap.java
+++ b/src/main/java/erjang/EMap.java
@@ -60,6 +60,11 @@ public final class EMap extends EObject {
 	public EAtom is_map() {
 		return ERT.TRUE;
 	}
+	
+	@Override
+	public EAtom is_map_g() {
+        return ERT.TRUE;
+	}
 
 	@Override
 	int compare_same(EObject rhs) {

--- a/src/main/java/erjang/EMap.java
+++ b/src/main/java/erjang/EMap.java
@@ -338,4 +338,18 @@ public final class EMap extends EObject {
 		}
 	}
     
+	@Override
+	public void encode(EOutputStream eos) {
+		eos.write_map_head(this.map_size());
+		
+        for(ISeq<IMapEntry<EObject, EObject>> iit = _map.seq();
+                iit != null;
+                iit = iit.next())
+        {
+            IMapEntry<EObject, EObject> ent = iit.first();
+            eos.write_any(ent.getKey());
+            eos.write_any(ent.getValue());
+        }
+	}
+	
 }

--- a/src/main/java/erjang/EObject.java
+++ b/src/main/java/erjang/EObject.java
@@ -381,11 +381,15 @@ public abstract class EObject {
 		return ERT.FALSE;
 	}
 
-	@BIF
-	public EAtom is_map() {
-		return ERT.FALSE;
-	}
-	
+    @BIF
+    public EAtom is_map() {
+        return ERT.FALSE;
+    }
+    
+    @BIF(type=BIF.Type.GUARD, name="is_map")
+    public EAtom is_map_g() {
+        return null;
+    }    
 
 	/**
 	 * @param o2

--- a/src/main/java/erjang/EObject.java
+++ b/src/main/java/erjang/EObject.java
@@ -101,6 +101,10 @@ public abstract class EObject {
 		return null;
 	}
 
+  public EMap testMap() {
+    return null;
+  }
+
 	public ECons testNonEmptyList() {
 		return null;
 	}
@@ -361,8 +365,9 @@ public abstract class EObject {
 	public static final int CMP_ORDER_PORT = 4;
 	public static final int CMP_ORDER_PID = 5;
 	public static final int CMP_ORDER_TUPLE = 6;
-	public static final int CMP_ORDER_LIST = 7;
-	public static final int CMP_ORDER_BITSTRING = 8;
+	public static final int CMP_ORDER_MAP = 7;
+	public static final int CMP_ORDER_LIST = 8;
+	public static final int CMP_ORDER_BITSTRING = 9;
 	
 	/** 
 	 * 	number[0] < atom[1] < reference[2] < fun[3] < port[4] < pid[5] < tuple[6] < list[7] < bit string[8]
@@ -375,7 +380,13 @@ public abstract class EObject {
 	public EAtom is_function(EObject arity) {
 		return ERT.FALSE;
 	}
+
+	@BIF
+	public EAtom is_map() {
+		return ERT.FALSE;
+	}
 	
+
 	/**
 	 * @param o2
 	 * @return

--- a/src/main/java/erjang/EOutputStream.java
+++ b/src/main/java/erjang/EOutputStream.java
@@ -910,4 +910,9 @@ public class EOutputStream extends ByteArrayOutputStream {
 	public ByteBuffer toByteBuffer() {
     	return ByteBuffer.wrap(super.buf, 0, super.count);
 	}
+
+	public void write_map_head(int arity) {
+	    write1(EExternal.mapTag);
+	    write4BE(arity);
+	}
 }

--- a/src/main/java/erjang/ERT.java
+++ b/src/main/java/erjang/ERT.java
@@ -75,6 +75,8 @@ public class ERT {
 		throw ERT.badarg(trace, value);
 	}
 
+  public static final EAtom am_badmap = EAtom.intern("badmap");
+  public static final EAtom am_badkey = EAtom.intern("badkey");
 	public static final EAtom am_badarg = EAtom.intern("badarg");
 	public static final EAtom am_notsup = EAtom.intern("notsup");
 	public static final EAtom AM_BADMATCH = EAtom.intern("badmatch");
@@ -96,6 +98,14 @@ public class ERT {
 	public static ErlangError badarg(EObject... args) {
 		throw new ErlangError(am_badarg, args);
 	}
+
+    public static ErlangError badkey(EObject key) {
+        throw new ErlangError(am_badkey, key);
+    }
+
+    public static ErlangError badmap(EObject obj) {
+        throw new ErlangError(am_badmap, obj);
+    }
 
 	/** Utility method throws <code>erlang:error('badarg', [o1, o2])</code>. */
 	public static ErlangError badarg(EObject o1, EObject o2) throws ErlangError {

--- a/src/main/java/erjang/beam/BeamOpcode.java
+++ b/src/main/java/erjang/beam/BeamOpcode.java
@@ -149,7 +149,12 @@ public enum BeamOpcode {
 	recv_set            (0x97),
 	gc_bif3             (0x98),
         line                (0x99),
-        
+
+        put_map_assoc       (0x9a),
+        put_map_exact       (0x9b),
+        is_map              (0x9c),
+        has_map_fields      (0x9d),
+        get_map_elements    (0x9e),
 
 	// Opcode groups
 	

--- a/src/main/java/erjang/beam/BlockVisitor2.java
+++ b/src/main/java/erjang/beam/BlockVisitor2.java
@@ -217,4 +217,7 @@ public interface BlockVisitor2 extends BlockVisitor {
 	void visitLine(int line);
 
 	void visitMakeTuple(int arity, Arg tuple_reg, Arg[] puts);
+
+	void visitMapQuery(BeamOpcode opcode, int label, Arg src, Arg[] keys, Arg[] dest);
+	void visitMapUpdate(BeamOpcode opcode, int label, Arg src, Arg dst, Arg[] keys, Arg[] srcs);
 }

--- a/src/main/java/erjang/beam/analysis/BeamTypeAnalysis.java
+++ b/src/main/java/erjang/beam/analysis/BeamTypeAnalysis.java
@@ -45,6 +45,7 @@ import erjang.EDouble;
 import erjang.EFun;
 import erjang.EInteger;
 import erjang.EList;
+import erjang.EMap;
 import erjang.EString;
 import erjang.ENil;
 import erjang.ENumber;
@@ -76,12 +77,12 @@ import erjang.beam.ModuleVisitor;
 import erjang.beam.Arg.Kind;
 import erjang.beam.repr.Insn;
 import erjang.beam.repr.ExtFun;
+import erjang.beam.repr.Insn.MapUpdate;
 import erjang.beam.repr.Insn.S;
 import erjang.beam.repr.Operands;
 import erjang.beam.repr.Operands.Int;
 import erjang.beam.repr.Operands.SourceOperand;
 import erjang.beam.repr.Operands.XReg;
-import static erjang.beam.repr.Operands.SourceOperand;
 import static erjang.beam.repr.Operands.DestinationOperand;
 import static erjang.beam.CodeAtoms.*;
 
@@ -109,6 +110,7 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 	static final Type ESEQ_TYPE = Type.getType(ESeq.class);
 	static final Type ELIST_TYPE = Type.getType(EList.class);
 	static final Type EFUN_TYPE = Type.getType(EFun.class);
+	static final Type EMAP_TYPE = Type.getType(EMap.class);
 	static final Type EPID_TYPE = Type.getType(EPID.class);
 	static final Type EPORT_TYPE = Type.getType(EPort.class);
 	static final Type EREFERENCE_TYPE = Type.getType(ERef.class);
@@ -613,6 +615,7 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 						
 						// Tests:
 						// LS:
+					case is_map:
 					case is_integer:
 					case is_float:
 					case is_number:
@@ -1124,8 +1127,50 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 						vis.visitBitStringAppend(opcode, decode_labelref(insn.label, type_map.exh), extra_size, src, unit, flags, dst);
 						break;
 					}
-					//default:
-					//	throw new Error("unhandled insn: " + insn_.toSymbolicTuple());
+					
+					case has_map_fields:
+					case get_map_elements:
+					{
+						Insn.MapQuery insn = (Insn.MapQuery) insn_;
+						
+						Arg src = src_arg(insn_idx, insn.src);
+						int label = decode_labelref(insn.defaultLabel, type_map.exh);
+
+						Arg[] keys = new Arg[ insn.kvs.size() ];
+						Arg[] dest = new Arg[ insn.kvs.size() ];
+						for (int i = 0; i < keys.length; i++) {
+							keys[i] = src_arg(insn_idx, insn.kvs.getKey(i) );
+							if (opcode == BeamOpcode.get_map_elements) {
+								dest[i] = dest_arg(insn_idx, insn.kvs.getKeyDest(i) );
+							}
+						}
+						
+						vis.visitMapQuery(opcode, label, src, keys, dest);
+						break;
+					}
+					
+					case put_map_assoc:
+					case put_map_exact:
+					{
+						Insn.MapUpdate insn = (Insn.MapUpdate) insn_;
+						
+						Arg src = src_arg(insn_idx, insn.src);
+						Arg dst = src_arg(insn_idx, insn.dest);
+						int label = decode_labelref(insn.defaultLabel, type_map.exh);
+
+						Arg[] keys = new Arg[ insn.kvs.size() ];
+						Arg[] srcs = new Arg[ insn.kvs.size() ];
+						for (int i = 0; i < keys.length; i++) {
+							keys[i] = src_arg(insn_idx, insn.kvs.getKey(i) );
+							srcs[i] = src_arg(insn_idx, insn.kvs.getKeySrc(i) );
+						}
+						
+						vis.visitMapUpdate(opcode, label, src, dst, keys, srcs);
+						break;
+					}
+					
+					default:
+						throw new Error("unhandled insn: " + insn_.toSymbolicTuple());
 					}
 
 				}
@@ -1665,6 +1710,7 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 
 						// Tests:
 						// LS:
+					case is_map:
 					case is_integer:
 					case is_float:
 					case is_number:
@@ -2100,11 +2146,52 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 						continue next_insn;
 					}
 
-                                        case line: {
-                                            // TODO: Implement LINE instruction!
-                                            continue next_insn;
-                                        }
+					case line: {
+						// TODO: Implement LINE instruction!
+						continue next_insn;
+					}
 
+					case get_map_elements:
+					case has_map_fields:
+					{
+						Insn.MapQuery insn = (Insn.MapQuery) insn_;
+						current = branch(current, insn.defaultLabel, insn_idx);
+
+						checkArg(current, insn.src);
+
+						Operands.SelectList kvs = insn.kvs;
+						int len = kvs.size();
+						for (int i=0; i<len; i++) {
+
+							if (code == BeamOpcode.get_map_elements) {
+								DestinationOperand dest = kvs.getKeyDest(i);
+								current = setType(current, dest, EOBJECT_TYPE);
+							}
+						}
+						
+						continue next_insn;
+					}
+					
+					case put_map_assoc:
+					case put_map_exact:
+					{
+						MapUpdate insn = (Insn.MapUpdate) insn_;
+						current = branch(current, insn.defaultLabel, insn_idx);
+
+						checkArg(current, insn.src);
+
+						Operands.SelectList kvs = insn.kvs;
+						int len = kvs.size();
+						for (int i=0; i<len; i++) {
+							checkArg(current, kvs.getKeySrc(i));
+						}
+						
+						current = setType(current, insn.dest, EMAP_TYPE);
+						
+						continue next_insn;
+					}
+					
+					
 					default: {
 						ETuple insn = insn_.toSymbolicTuple();
 						throw new Error("unhandled: " + insn + "::" + current);
@@ -2421,6 +2508,7 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 				case is_reference: return EREFERENCE_TYPE;
 				case is_float:     return EDOUBLE_TYPE;
 				case is_function:  return EFUN_TYPE;
+				case is_map:       return EMAP_TYPE;
 
 				case is_list:
 				case is_nonempty_list:

--- a/src/main/java/erjang/beam/analysis/BeamTypeAnalysis.java
+++ b/src/main/java/erjang/beam/analysis/BeamTypeAnalysis.java
@@ -1129,6 +1129,22 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 					}
 					
 					case has_map_fields:
+                    {
+                        Insn.MapQuery insn = (Insn.MapQuery) insn_;
+                        
+                        Arg src = src_arg(insn_idx, insn.src);
+                        int label = decode_labelref(insn.defaultLabel, type_map.exh);
+
+                        Arg[] keys = new Arg[ insn.kvs.size(true) ];
+                        Arg[] dest = new Arg[0];
+                        for (int i = 0; i < keys.length; i++) {
+                            keys[i] = src_arg(insn_idx, insn.kvs.getKey(i, true) );
+                        }
+                        
+                        vis.visitMapQuery(opcode, label, src, keys, dest);
+                        break;
+                    }
+                    
 					case get_map_elements:
 					{
 						Insn.MapQuery insn = (Insn.MapQuery) insn_;
@@ -1136,13 +1152,11 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 						Arg src = src_arg(insn_idx, insn.src);
 						int label = decode_labelref(insn.defaultLabel, type_map.exh);
 
-						Arg[] keys = new Arg[ insn.kvs.size() ];
-						Arg[] dest = new Arg[ insn.kvs.size() ];
+						Arg[] keys = new Arg[ insn.kvs.size(false) ];
+						Arg[] dest = new Arg[ insn.kvs.size(false) ];
 						for (int i = 0; i < keys.length; i++) {
-							keys[i] = src_arg(insn_idx, insn.kvs.getKey(i) );
-							if (opcode == BeamOpcode.get_map_elements) {
-								dest[i] = dest_arg(insn_idx, insn.kvs.getKeyDest(i) );
-							}
+							keys[i] = src_arg(insn_idx, insn.kvs.getKey(i, false) );
+							dest[i] = dest_arg(insn_idx, insn.kvs.getKeyDest(i) );
 						}
 						
 						vis.visitMapQuery(opcode, label, src, keys, dest);
@@ -1161,7 +1175,7 @@ public class BeamTypeAnalysis extends ModuleAdapter {
 						Arg[] keys = new Arg[ insn.kvs.size() ];
 						Arg[] srcs = new Arg[ insn.kvs.size() ];
 						for (int i = 0; i < keys.length; i++) {
-							keys[i] = src_arg(insn_idx, insn.kvs.getKey(i) );
+							keys[i] = src_arg(insn_idx, insn.kvs.getKey(i, false) );
 							srcs[i] = src_arg(insn_idx, insn.kvs.getKeySrc(i) );
 						}
 						

--- a/src/main/java/erjang/beam/interpreter/Interpreter.template
+++ b/src/main/java/erjang/beam/interpreter/Interpreter.template
@@ -23,6 +23,7 @@ import java.util.List;
 import erjang.EModule;
 import erjang.EModuleManager;
 import erjang.EFun;
+import erjang.EMap;
 import erjang.EFunHandler;
 import erjang.codegen.EFunCG;
 import erjang.FunID;

--- a/src/main/java/erjang/beam/loader/BeamLoader.java
+++ b/src/main/java/erjang/beam/loader/BeamLoader.java
@@ -1297,11 +1297,10 @@ public class BeamLoader extends CodeTables {
 			}
 			case SELECTLIST_TAG2: {
 				int length = readCodeInteger();
-				assert(length % 2 == 0);
+				//if(length % 2 != 0) throw new Error("bad select list length: "+length);
 				Operand[] list = new Operand[length];
-				for (int i=0; i<length; ) {
-					list[i++] = readOperand();
-					list[i++] = readOperand();
+				for (int i=0; i<length; i++) {
+					list[i] = readOperand();
 				}
 				return new SelectList(list);
 			}

--- a/src/main/java/erjang/beam/loader/BeamLoader.java
+++ b/src/main/java/erjang/beam/loader/BeamLoader.java
@@ -739,6 +739,7 @@ public class BeamLoader extends CodeTables {
 				return new Insn.YL(opcode, y, label);
 			}
 
+			case is_map:
 			case is_integer:
 			case is_float:
 			case is_number:
@@ -1092,6 +1093,29 @@ public class BeamLoader extends CodeTables {
 				return new Insn.GcBif(opcode, optLabel, extFun(ext_fun_ref), save, arg1, arg2, arg3, dest);
 			}
 
+			// map operations
+			
+			case get_map_elements:
+			case has_map_fields:
+			{
+				Label optlabel = readOptionalLabel();
+				SourceOperand map = readSource();
+				SelectList mapKeys = readSelectList();
+				return new Insn.MapQuery(opcode, optlabel, map, mapKeys);
+			}
+			
+			case put_map_assoc:
+			case put_map_exact:
+			{
+				Label optlabel = readOptionalLabel();
+				SourceOperand src = readSource();
+				DestinationOperand dest = readDestination();
+				int _n = readCodeInteger();
+				SelectList mapKeyValues = readSelectList();
+				return new Insn.MapUpdate(opcode, optlabel, src, _n, mapKeyValues, dest);
+			}
+			
+			
 			default:
 				throw new IOException("Unknown instruction: "+opcode);
 			} // switch
@@ -1277,7 +1301,7 @@ public class BeamLoader extends CodeTables {
 				Operand[] list = new Operand[length];
 				for (int i=0; i<length; ) {
 					list[i++] = readOperand();
-					list[i++] = readLabel();
+					list[i++] = readOperand();
 				}
 				return new SelectList(list);
 			}

--- a/src/main/java/erjang/beam/repr/Insn.java
+++ b/src/main/java/erjang/beam/repr/Insn.java
@@ -27,6 +27,7 @@ import static erjang.beam.CodeAtoms.GCBIF_ATOM;
 import static erjang.beam.CodeAtoms.NOFAIL_ATOM;
 import static erjang.beam.CodeAtoms.START_ATOM;
 import static erjang.beam.CodeAtoms.TEST_ATOM;
+
 import erjang.EList;
 import erjang.EObject;
 import erjang.ERT;
@@ -40,7 +41,6 @@ import erjang.beam.repr.Operands.BitString;
 import erjang.beam.repr.Operands.ByteString;
 import erjang.beam.repr.Operands.DestinationOperand;
 import erjang.beam.repr.Operands.Label;
-import erjang.beam.repr.Operands.MapList;
 import erjang.beam.repr.Operands.SelectList;
 import erjang.beam.repr.Operands.SourceOperand;
 import erjang.beam.repr.Operands.XReg;

--- a/src/main/java/erjang/beam/repr/Insn.java
+++ b/src/main/java/erjang/beam/repr/Insn.java
@@ -40,12 +40,14 @@ import erjang.beam.repr.Operands.BitString;
 import erjang.beam.repr.Operands.ByteString;
 import erjang.beam.repr.Operands.DestinationOperand;
 import erjang.beam.repr.Operands.Label;
+import erjang.beam.repr.Operands.MapList;
 import erjang.beam.repr.Operands.SelectList;
 import erjang.beam.repr.Operands.SourceOperand;
 import erjang.beam.repr.Operands.XReg;
 import erjang.beam.repr.Operands.YReg;
 
 public class Insn implements BeamInstruction {
+
 	protected final BeamOpcode opcode;
 	public Insn(BeamOpcode opcode) {this.opcode = opcode;}
 	public BeamOpcode opcode() {return opcode;}
@@ -990,6 +992,59 @@ public class Insn implements BeamInstruction {
 							   src.toSymbolic(),
 							   defaultLabel.toSymbolic(),
 							   jumpTable.toSymbolic());
+		}
+	}
+
+
+	public static class MapQuery extends Insn { // E.g. 'select_val'
+		public final SourceOperand src;
+		public final Label defaultLabel;
+		public final SelectList kvs; // TODO: Improve representation.
+		public MapQuery(BeamOpcode opcode,
+					  Label defaultLabel,
+					  SourceOperand map,
+					  SelectList kvs)
+		{
+			super(opcode);
+			this.src = map;
+			this.defaultLabel = defaultLabel;
+			this.kvs = kvs;
+		}
+		public ETuple toSymbolic() {
+			return ETuple.make(opcode.symbol,
+							   defaultLabel.toSymbolic(),
+							   src.toSymbolic(),
+							   kvs.toSymbolic());
+		}
+	}
+
+	public static class MapUpdate extends Insn { // E.g. 'select_val'
+		public final SourceOperand src;
+		public final Label defaultLabel;
+		public final SelectList kvs; // TODO: Improve representation.
+		public final DestinationOperand dest;
+		private int kvCount;
+		public MapUpdate(BeamOpcode opcode,
+					  Label defaultLabel,
+					  SourceOperand map,
+					  int kvCount, 
+					  SelectList kvs,
+					  DestinationOperand dest)
+		{
+			super(opcode);
+			this.src = map;
+			this.defaultLabel = defaultLabel;
+			this.kvs = kvs;
+			this.kvCount = kvCount;
+			this.dest = dest;
+		}
+		public ETuple toSymbolic() {
+			return ETuple.make(opcode.symbol,
+							   defaultLabel.toSymbolic(),
+							   src.toSymbolic(),
+							   dest.toSymbolic(),
+							   ESmall.make(kvCount),
+							   kvs.toSymbolic());
 		}
 	}
 

--- a/src/main/java/erjang/beam/repr/Operands.java
+++ b/src/main/java/erjang/beam/repr/Operands.java
@@ -191,6 +191,32 @@ public class Operands {
 		public int size() {return list.length / 2;}
 		public Operand getValue(int i) {return list[2*i];}
 		public Label getLabel(int i)   {return (Label)list[2*i+1];}
+		
+		// when used in MapQuery/MapUpdate insns
+		public SourceOperand getKey(int i)   {return (SourceOperand)list[2*i];}
+		public DestinationOperand getKeyDest(int i)   {return (DestinationOperand)list[2*i+1];}
+		public SourceOperand getKeySrc(int i)   {return (SourceOperand)list[2*i+1];}
+
+		public EObject toSymbolic() {
+			EObject[] elems = new EObject[list.length];
+			for (int i=0; i<list.length; i++) {
+				elems[i] = list[i].toSymbolic();
+			}
+			return ETuple.make(LIST_ATOM, ESeq.fromArray(elems));
+		}
+    }
+
+    public static class MapList extends Operand {
+		Operand[] list;
+		public MapList(Operand[] list) {this.list=list;}
+
+		@Override
+		public MapList asMapList() {return this;}
+
+		public int size() {return list.length / 2;}
+		public SourceOperand      getKey(int i)    {return list[2*i].asSource();}
+		public DestinationOperand getDest(int i)   {return list[2*i+1].asDestination();}
+		public SourceOperand      getSource(int i) {return list[2*i+1].asSource();}
 
 		public EObject toSymbolic() {
 			EObject[] elems = new EObject[list.length];

--- a/src/main/java/erjang/beam/repr/Operands.java
+++ b/src/main/java/erjang/beam/repr/Operands.java
@@ -206,27 +206,6 @@ public class Operands {
 		}
     }
 
-    public static class MapList extends Operand {
-		Operand[] list;
-		public MapList(Operand[] list) {this.list=list;}
-
-		@Override
-		public MapList asMapList() {return this;}
-
-		public int size() {return list.length / 2;}
-		public SourceOperand      getKey(int i)    {return list[2*i].asSource();}
-		public DestinationOperand getDest(int i)   {return list[2*i+1].asDestination();}
-		public SourceOperand      getSource(int i) {return list[2*i+1].asSource();}
-
-		public EObject toSymbolic() {
-			EObject[] elems = new EObject[list.length];
-			for (int i=0; i<list.length; i++) {
-				elems[i] = list[i].toSymbolic();
-			}
-			return ETuple.make(LIST_ATOM, ESeq.fromArray(elems));
-		}
-    }
-
     public static class AllocList extends Operand {
 		static final int WORDS  = 0;
 		static final int FLOATS = 1;

--- a/src/main/java/erjang/beam/repr/Operands.java
+++ b/src/main/java/erjang/beam/repr/Operands.java
@@ -193,7 +193,14 @@ public class Operands {
 		public Label getLabel(int i)   {return (Label)list[2*i+1];}
 		
 		// when used in MapQuery/MapUpdate insns
-		public SourceOperand getKey(int i)   {return (SourceOperand)list[2*i];}
+        public int size(boolean keys_only) {
+            if (keys_only) return list.length;
+            return list.length / 2;
+        }
+		public SourceOperand getKey(int i, boolean keys_only) {
+		    if (keys_only) return (SourceOperand)list[i];
+		    return (SourceOperand)list[2*i];
+		}
 		public DestinationOperand getKeyDest(int i)   {return (DestinationOperand)list[2*i+1];}
 		public SourceOperand getKeySrc(int i)   {return (SourceOperand)list[2*i+1];}
 

--- a/src/main/java/erjang/m/erlang/ErlBif.java
+++ b/src/main/java/erjang/m/erlang/ErlBif.java
@@ -49,6 +49,7 @@ import erjang.EDouble;
 import erjang.EFun;
 import erjang.EIOListVisitor;
 import erjang.EInteger;
+import erjang.EMap;
 import erjang.EModule;
 import erjang.EModuleLoader;
 import erjang.EModuleManager;
@@ -2383,4 +2384,18 @@ public class ErlBif {
 		return ERT.box( bif != null );
 	}
     
+	@BIF
+    public static ESmall map_size(EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return ERT.box(self.map_size());
+	}
+	
+	@BIF(type=Type.GUARD, name="map_size")
+    public static ESmall map_size_g(EObject map) {
+		EMap self = map.testMap();
+		if (self == null) return null;
+		return ERT.box(self.map_size());
+	}
+	
 }

--- a/src/main/java/erjang/m/ets/EPattern.java
+++ b/src/main/java/erjang/m/ets/EPattern.java
@@ -33,6 +33,7 @@ import erjang.EBitString;
 import erjang.ECons;
 import erjang.EFun;
 import erjang.EList;
+import erjang.EMap;
 import erjang.ENumber;
 import erjang.EObject;
 import erjang.EPID;
@@ -407,6 +408,11 @@ public class EPattern {
 	/** generic compare-equals matcher */
 	public static ETermPattern compilePattern(EObject epid, Set<Integer> out) {
 		return new ValuePattern(epid);
+	}
+
+	public static ETermPattern compilePattern(EMap map, Set<Integer> out) {
+		// TODO: Map matching semantics?
+		return new ValuePattern(map);
 	}
 
 	/**

--- a/src/main/java/erjang/m/ets/ETermPattern.java
+++ b/src/main/java/erjang/m/ets/ETermPattern.java
@@ -23,6 +23,7 @@ import erjang.EAtom;
 import erjang.EBitString;
 import erjang.ECons;
 import erjang.EFun;
+import erjang.EMap;
 import erjang.ENumber;
 import erjang.EObject;
 import erjang.EPID;
@@ -31,6 +32,10 @@ import erjang.ERef;
 import erjang.ETuple;
 
 public abstract class ETermPattern {
+	public boolean match(EMap m, EMatchContext r) {
+		return false;
+	}
+
 	public boolean match(ETuple t, EMatchContext r) {
 		return false;
 	}

--- a/src/main/java/erjang/m/maps/Native.java
+++ b/src/main/java/erjang/m/maps/Native.java
@@ -1,0 +1,119 @@
+/**
+ * This file is part of Erjang - A JVM-based Erlang VM
+ *
+ * Copyright (c) 2015 by Trifork
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+ package erjang.m.maps;
+
+import com.trifork.clj_ds.PersistentHashMap;
+
+import erjang.BIF;
+import erjang.EAtom;
+import erjang.EList;
+import erjang.EMap;
+import erjang.ENative;
+import erjang.EObject;
+import erjang.ERT;
+import erjang.ESeq;
+
+public class Native extends ENative {
+
+	@BIF public static
+	EObject get(EObject key, EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return self.get(key);		
+	}
+	
+	@BIF public static
+	EObject get(EObject key, EObject map, EObject defaultValue) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return self.get(key, defaultValue);		
+	}
+	
+	@BIF public static
+	EMap put(EObject key, EObject value, EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return self.put(key, value);
+	}
+	
+	@BIF public static
+	EMap update(EObject key, EObject value, EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		if (!self.containsKey(key)) throw ERT.badkey(key);
+		return self.put(key, value);
+	}
+	
+	@BIF public static
+	EMap remove(EObject key, EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return self.remove(key);
+	}
+	
+	@BIF public static
+	EAtom is_key(EObject key, EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return self.is_key(key);		
+	}
+	
+	@BIF public static
+	ESeq keys(EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return self.keys();
+	}
+	
+	@BIF public static
+	ESeq values(EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return self.values();
+	}
+	
+	@BIF public static
+	ESeq to_list(EObject map) {
+		EMap self = map.testMap();
+		if (self == null) throw ERT.badmap(map);
+		return self.to_list();
+	}
+	
+	@BIF public static
+	EMap merge(EObject map1, EObject map2) {
+
+		EMap self1 = map1.testMap();
+		if (self1 == null) throw ERT.badmap(map1);
+
+		EMap self2 = map2.testMap();
+		if (self2 == null) throw ERT.badmap(map2);
+
+		return self1.merge(self2);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@BIF(name="new") public static
+	EMap new_map() {
+		return EMap.EMPTY;
+	}
+	
+	
+	
+	
+}

--- a/src/main/java/erjang/m/maps/Native.java
+++ b/src/main/java/erjang/m/maps/Native.java
@@ -88,13 +88,20 @@ public class Native extends ENative {
 		return self.values();
 	}
 	
-	@BIF public static
-	ESeq to_list(EObject map) {
-		EMap self = map.testMap();
-		if (self == null) throw ERT.badmap(map);
-		return self.to_list();
-	}
-	
+    @BIF public static
+    ESeq to_list(EObject map) {
+        EMap self = map.testMap();
+        if (self == null) throw ERT.badmap(map);
+        return self.to_list();
+    }
+    
+    @BIF public static
+    EMap from_list(EObject map) {
+        ESeq seq = map.testSeq();
+        if (seq == null) throw ERT.badarg(map);
+        return EMap.from_list(seq);
+    }
+    
 	@BIF public static
 	EMap merge(EObject map1, EObject map2) {
 

--- a/src/main/java/erjang/m/maps/Native.java
+++ b/src/main/java/erjang/m/maps/Native.java
@@ -18,11 +18,9 @@
 
  package erjang.m.maps;
 
-import com.trifork.clj_ds.PersistentHashMap;
-
 import erjang.BIF;
+import erjang.BIF.Type;
 import erjang.EAtom;
-import erjang.EList;
 import erjang.EMap;
 import erjang.ENative;
 import erjang.EObject;
@@ -30,6 +28,13 @@ import erjang.ERT;
 import erjang.ESeq;
 
 public class Native extends ENative {
+
+    @BIF public static
+    EObject find(EObject key, EObject map) {
+        EMap self = map.testMap();
+        if (self == null) throw ERT.badmap(map);
+        return self.find(key);       
+    }
 
 	@BIF public static
 	EObject get(EObject key, EObject map) {
@@ -67,13 +72,13 @@ public class Native extends ENative {
 		return self.remove(key);
 	}
 	
-	@BIF public static
-	EAtom is_key(EObject key, EObject map) {
-		EMap self = map.testMap();
-		if (self == null) throw ERT.badmap(map);
-		return self.is_key(key);		
-	}
-	
+    @BIF public static
+    EAtom is_key(EObject key, EObject map) {
+        EMap self = map.testMap();
+        if (self == null) throw ERT.badmap(map);
+        return self.is_key(key);        
+    }
+    
 	@BIF public static
 	ESeq keys(EObject map) {
 		EMap self = map.testMap();


### PR DESCRIPTION
With this set of changes, Erlang now boots on R18 and can successfully compile a module from the REPL.

The changes are relatively orthogonal; the only tricky thing is that maps also use the `SelectList` operand type (that's the way it is encoded in BEAM), so there are some strange new methods on SelectList to consider it a KV-list of operands for the map operations.