### PR TITLE
add build-with ant task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Generated files:
 /target
+/classes
 *_TEST.java
 /x86_64-apple-darwin12.4.0
 /x86_64-unknown-linux-gnu
@@ -7,7 +8,11 @@ test-outputs
 /bootstrap
 /test_server/*.beam
 */.erjang/*.jar
+erjang.log
 *.beam
+erjang*.jar
+otp*.jar
+src/main/java/erjang/beam/interpreter
 
 # IDE specifics:
 /.idea

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Total time: 20 seconds
 ````
 Then, just run `java -jar erjang-R16B01.jar`
 
+Or you can build it with a local erlang distribution. Use the build-with ant task with an src parameter pointing at the erlang distribution's directory:
+
+````
+>which erl
+      /usr/lib/erlang/bin
+
+>ant build-with -Dsrc=/usr/lib/erlang
+      ...
+      BUILD SUCCESSFUL
+````
+
 ### How does it work?
 
 It loads Erlang's binary `.beam` file format, compiles it into Java's `.class` file format, and loads it into the JVM.   It will eventually have it's own implementation of all Erlang's BIFs (built-in-functions) written in Java.  

--- a/build.xml
+++ b/build.xml
@@ -310,7 +310,7 @@
     </jar>
   </target>
 
-  <target name="otpjar" depends="get_otp_version">
+  <target name="otpjar">
     <jar jarfile="otp-${erjang.otp.version}.jar" basedir="${erjang.otp.root}">
       <exclude name="**/*.so" />
       <exclude name="**/*.dll" />
@@ -330,6 +330,9 @@
   </target>
 
   <target name="alljar" depends="jar,otpjar">
+    <property name="erjang.otp.root" value="${basedir}/${otp_arch}" />
+    <antcall target="get_otp_version" />
+    <antcall target="otpjar" />
     <jar jarfile="erjang-${erjang.otp.version}.jar" basedir="${erjang.otp.root}">
       <!-- include all of erjang -->
       <zipgroupfileset dir="." includes="erjang-${erjang.version}.jar" />
@@ -341,6 +344,22 @@
       </manifest>
     </jar>
   </target>
+
+<target name="build-with" if="isLinux" depends="arch">
+  <property name="erjang.otp.root" value="${basedir}/${otp_arch}" />
+  <symlink link="${otp_arch}" resource="${src}" overwrite="true"/>
+  <antcall target="jar" />
+  <antcall target="otpjar" />
+  <jar jarfile="erjang.jar" basedir="${erjang.otp.root}">
+    <!-- include all of erjang -->
+    <zipgroupfileset dir="." includes="erjang-${erjang.version}.jar" />
+    <!-- include all of OTP -->
+    <zipgroupfileset dir="." includes="otp.jar" />
+    <manifest>
+      <attribute name="Main-Class" value="erjang.Main" />
+    </manifest>
+  </jar>
+</target>
 
   <target name="javadoc" description="generate Javadoc documentation">
     <javadoc destdir="target/doc">


### PR DESCRIPTION
I added a new ant task to help the building with a locally available erlang distribution. I allowed to run this only on Linux sice this is not tested on other platforms
Tested on Ubuntu 16.04